### PR TITLE
Add JSON Schema for Users and Tasks Collections

### DIFF
--- a/task-schema.json
+++ b/task-schema.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "completed": {
+      "type": "boolean",
+      "description": "Indicates whether the task is completed."
+    },
+    "created": {
+      "type": "string",
+      "format": "date-time",
+      "description": "The timestamp when the task was created (ISO 8601)."
+    },
+    "details": {
+      "type": "string",
+      "description": "The details or description of the task."
+    },
+    "title": {
+      "type": "string",
+      "description": "The title of the task."
+    },
+    "user": {
+      "type": "string",
+      "description": "Reference to the user who owns the task (Firestore document reference)."
+    }
+  },
+  "required": ["completed", "created", "details", "title", "user"]
+}

--- a/user-schema.json
+++ b/user-schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "bio": {
+      "type": "string",
+      "description": "The user's biography or description."
+    },
+    "birthday": {
+      "type": "string",
+      "format": "date-time",
+      "description": "The user's birthday (ISO 8601 timestamp)."
+    },
+    "created_time": {
+      "type": "string",
+      "format": "date-time",
+      "description": "The timestamp when the user was created (ISO 8601)."
+    },
+    "display_name": {
+      "type": "string",
+      "description": "The user's display name."
+    },
+    "email": {
+      "type": "string",
+      "format": "email",
+      "description": "The user's email address."
+    },
+    "photo_url": {
+      "type": "string",
+      "format": "uri",
+      "description": "URL of the user's profile picture."
+    },
+    "uid": {
+      "type": "string",
+      "description": "Unique identifier for the user."
+    }
+  },
+  "required": ["bio", "birthday", "created_time", "display_name", "email", "uid"]
+}


### PR DESCRIPTION
Propose Changes:
This pull request adds two new JSON schema files for validating Firestore documents in the ToDo app:
user-schema.json: Defines the schema for the users collection, which includes fields such as bio, birthday, created_time, display_name, email, photo_url, and uid.
task-schema.json: Defines the schema for the tasks collection, including fields like completed, created, details, title, and a reference to the user.

Address Merge Conflicts:
If any merge conflicts arise when merging this branch into the main branch (e.g., changes to directory structure or other schemas), I will:
Review the changes that caused the conflict.
Reach out to collaborators if needed to understand their changes.
Resolve the conflict by ensuring both sets of changes are properly integrated (e.g., by keeping relevant changes from both sides).
Test that the new schema files do not interfere with existing functionality.